### PR TITLE
build(packages/clients/consensus/nimbus-eth2): Ensure Nim 1.6 is used

### DIFF
--- a/packages/clients/consensus/nimbus-eth2/default.nix
+++ b/packages/clients/consensus/nimbus-eth2/default.nix
@@ -22,7 +22,7 @@
 # Nim version(s) that are known to be stable
 assert (
   lib.assertMsg
-  (nim.version == "1.6.12" || nim.version == "1.6.14")
+  (builtins.elem nim.version ["1.6.12" "1.6.14" "v1.6.16"])
   "Unsupported Nim version: ${nim.version}"
 );
   stdenv.mkDerivation rec {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -20,7 +20,13 @@
       lighthouse = callPackage ./clients/consensus/lighthouse {inherit foundry;};
       prysm = callPackage ./clients/consensus/prysm {inherit bls blst;};
       teku = callPackage ./clients/consensus/teku {};
-      nimbus-eth2 = callPackageUnstable ./clients/consensus/nimbus-eth2 {};
+      nimbus-eth2 = callPackageUnstable ./clients/consensus/nimbus-eth2 {
+        # For now the nimbus team prefers nim 1.6 over 2.0.
+        # In newer versions of `pkgsUnstable` `nim` points to v2.0.0 in older it is 1.6.
+        # In newer versions the `nim1` package exists but not in older.
+        # See: https://github.com/status-im/nimbus-build-system/commits/master/vendor
+        nim = pkgsUnstable.nim1 or pkgsUnstable.nim;
+      };
 
       # Execution Clients
       erigon = callPackage ./clients/execution/erigon {};
@@ -74,7 +80,7 @@
 
       # Solidity
       slither = callPackageUnstable ./solidity/analyzers/slither {};
-      wake = callPackageUnstable ./solidity/frameworks/wake { inherit poetry2nix; };
+      wake = callPackageUnstable ./solidity/frameworks/wake {inherit poetry2nix;};
 
       # Libs
       evmc = callPackage ./libs/evmc {};


### PR DESCRIPTION
In newer versions of `nixpkgs-unstable` the `nim` package points to
`2.0.0`. A new package `nim1` has been added for backwards
compatibility.

Since we can't be sure with what version of nixpkgs-unstable we will be
instantiated fallback to `nim` if `nim1` does not exist.
