### PR TITLE
config(modules/baseServiceConfig): Revert ProcSubset=pid (default is all)

### DIFF
--- a/modules/geth/default.nix
+++ b/modules/geth/default.nix
@@ -121,7 +121,6 @@ in {
               serviceConfig = mkMerge [
                 baseServiceConfig
                 {
-                  ProcSubset = "all";
                   User = serviceName;
                   StateDirectory = serviceName;
                   ExecStart = "${cfg.package}/bin/geth ${scriptArgs}";

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -81,7 +81,6 @@ lib: let
     #   * ProtectHome = "read-only"
     DynamicUser = mkDefault true;
 
-    ProcSubset = mkDefault "pid";
     ProtectClock = mkDefault true;
     ProtectProc = mkDefault "noaccess";
     ProtectKernelLogs = mkDefault true;


### PR DESCRIPTION
`ProcSubset=pid` causes various problems for both nimbus and geth
(and possibly other services), so it's better to revert that change.
