### PR TITLE
refactor(modules): Refactor `geth`, `nethermind` and `nimbus` port types

### DIFF
--- a/modules/geth/args.nix
+++ b/modules/geth/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   port = mkOption {
-    type = types.port;
+    type = types.either types.port (types.enum ["\${PORT}"]);
     default = 30303;
     description = mdDoc "Port number Go Ethereum will be listening on, both TCP and UDP.";
   };
@@ -16,7 +16,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${HTTP_PORT}"]);
       default = 8545;
       description = mdDoc "Port number of Go Ethereum HTTP API.";
     };
@@ -62,7 +62,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${WS_PORT}"]);
       default = 8546;
       description = mdDoc "Port number of Go Ethereum WebSocket API.";
     };
@@ -83,7 +83,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${AUTHRPC_PORT}"]);
       default = 8551;
       description = mdDoc "Port number of Go Ethereum Auth RPC API.";
     };
@@ -112,7 +112,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["METRICS_PORT"]);
       default = 6060;
       description = mdDoc "Port number of Go Ethereum metrics service.";
     };
@@ -215,7 +215,7 @@ with lib; {
 
   discovery = {
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${DISCOVERY_PORT}"]);
       default = 30303;
       description = mdDoc "Use a custom UDP port for P2P discovery.";
     };

--- a/modules/nethermind/args.nix
+++ b/modules/nethermind/args.nix
@@ -26,14 +26,7 @@ with lib; {
   };
 
   log = mkOption {
-    type = types.enum [
-      "OFF"
-      "TRACE"
-      "DEBUG"
-      "INFO"
-      "WARN"
-      "ERROR"
-    ];
+    type = types.enum ["OFF" "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "\${LOG}"];
     default = "INFO";
     description = mdDoc "Changes the logging level.";
   };

--- a/modules/nethermind/args.nix
+++ b/modules/nethermind/args.nix
@@ -48,13 +48,13 @@ with lib; {
     # https://docs.nethermind.io/nethermind/ethereum-client/configuration/network
     Network = {
       DiscoveryPort = mkOption {
-        type = types.port;
+        type = types.either types.port (types.enum ["\${DISCOVERY_PORT}"]);
         default = 30303;
         description = mdDoc "UDP port number for incoming discovery connections.";
       };
 
       P2PPort = mkOption {
-        type = types.port;
+        type = types.either types.port (types.enum ["\${P2P_PORT}"]);
         default = 30303;
         description = mdDoc "TPC/IP port number for incoming P2P connections.";
       };
@@ -69,13 +69,13 @@ with lib; {
       };
 
       Port = mkOption {
-        type = types.port;
+        type = types.either types.port (types.enum ["\${PORT}"]);
         default = 8545;
         description = mdDoc "Port number for JSON RPC calls.";
       };
 
       WebSocketsPort = mkOption {
-        type = types.port;
+        type = types.either types.port (types.enum ["\${WEB_SOCKETS_PORT}"]);
         default = 8545;
         description = mdDoc "Port number for JSON RPC web sockets calls.";
       };
@@ -87,7 +87,7 @@ with lib; {
       };
 
       EnginePort = mkOption {
-        type = types.port;
+        type = types.either types.port (types.enum ["\${ENGINE_PORT}"]);
         default = 8551;
         description = mdDoc "Port for Execution Engine calls.";
       };
@@ -118,7 +118,7 @@ with lib; {
       };
 
       ExposePort = mkOption {
-        type = types.nullOr types.port;
+        type = types.nullOr (types.either types.port (types.enum ["\${METRICS_EXPOSE_PORT}"]));
         default = null;
         description = mdDoc "If 'true' then Health Check endpoints is enabled at /health";
       };

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -17,13 +17,13 @@ with lib; {
   };
 
   udp-port = mkOption {
-    type = types.port;
+    type = types.either types.port (types.enum ["\${UDP_PORT}"]);
     default = 12000;
     description = mdDoc "The port used by discv5.";
   };
 
   tcp-port = mkOption {
-    type = types.port;
+    type = types.either types.port (types.enum ["\${TCP_PORT}"]);
     default = 13000;
     description = mdDoc "The port used by libp2p.";
   };
@@ -69,7 +69,7 @@ with lib; {
       description = mdDoc "Metrics address for beacon node.";
     };
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${METRICS_PORT}"]);
       default = 8008;
       description = mdDoc "Metrics port for beacon node.";
     };
@@ -84,7 +84,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${REST_PORT}"]);
       default = 5052;
       description = mdDoc "Port for the REST API server.";
     };
@@ -152,7 +152,7 @@ with lib; {
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.either types.port (types.enum ["\${KEYMANAGER_PORT}"]);
       default = 5052;
       description = mdDoc "Listening port for the REST keymanager API.";
     };

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -92,7 +92,7 @@ with lib; {
 
   log = {
     level = mkOption {
-      type = types.enum ["trace" "debug" "info" "notice" "warn" "error" "fatal" "none"];
+      type = types.enum ["trace" "debug" "info" "notice" "warn" "error" "fatal" "none" "\${LOG_LEVEL}"];
       default = "info";
       example = "debug";
       description = mdDoc "Logging level.";


### PR DESCRIPTION
- refactor(modules/nimbus-eth2): Allow using both string and port in port options
- refactor(modules/nimbus-eth2): Use types of string instead enum for `log.level`
- refactor(modules/geth): Use both string and port in port options
- refactor(modules/nethermind): Use both string and port in port options
- refactor(modules/nethermind): Use types of string instead enum for log
