### PR TITLE
build(pkgs/foundry): Use stable fenix rust channel

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,7 +28,7 @@
     callPackage2311 = pkgs2311.callPackage;
     callPackageNethermind = pkgsNethermind.callPackage;
 
-    rustToolchain = inputs'.fenix.packages.minimal.toolchain;
+    rustToolchain = inputs'.fenix.packages.stable.toolchain;
 
     rustPlatform = pkgsUnstable.makeRustPlatform {
       cargo = rustToolchain;


### PR DESCRIPTION
`inputs'.fenix.packages.minimal` uses the nightly channel, which can easily introduce instability in our builds.