### PR TITLE
update(pkgs): Update nimbus, geth, nethermind, mev-boost, and web3signer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1738644632,
-        "narHash": "sha256-DyvJjOOGmTSkkEfHq0oWkwtZOgejYIB5S865wmf/qos=",
+        "lastModified": 1743014863,
+        "narHash": "sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "95ea544c84ebed84a31896b0ecea2570e5e0e236",
+        "rev": "bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -182,6 +182,29 @@
         "type": "github"
       }
     },
+    "nimbus-eth2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742560866,
+        "narHash": "sha256-3/FXHzq6YrJUNa9/nHaV8xXn3IOqCT5ymf6VU6wlXIk=",
+        "ref": "v25.3.1",
+        "rev": "283ee0b3e86028c8dbd190cfe6d25f4063b451f7",
+        "revCount": 7262,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/status-im/nimbus-eth2"
+      },
+      "original": {
+        "ref": "v25.3.1",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/status-im/nimbus-eth2"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1717179513,
@@ -240,6 +263,7 @@
         "flake-utils": "flake-utils",
         "foundry-nix": "foundry-nix",
         "lib-extras": "lib-extras",
+        "nimbus-eth2": "nimbus-eth2",
         "nixpkgs": "nixpkgs",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,10 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    nimbus-eth2 = {
+      url = "git+https://github.com/status-im/nimbus-eth2?ref=v25.3.1&submodules=1";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
   };
 
   outputs = inputs @ {

--- a/flake.nix
+++ b/flake.nix
@@ -150,7 +150,7 @@
               "*.md"
               "*.html"
             ];
-            mdformat.package = lib.mkDefault (pkgsUnstable.mdformat.withPlugins (p: [
+            mdformat.package = lib.mkDefault (pkgs.mdformat.withPlugins (p: [
               p.mdformat-admon
               p.mdformat-beautysh
               p.mdformat-footnote

--- a/modules/geth/args.nix
+++ b/modules/geth/args.nix
@@ -160,6 +160,7 @@ with lib; {
         "rinkeby"
         "ropsten"
         "sepolia"
+        "hoodi"
       ]
     );
     default = null;

--- a/modules/mev-boost/args.nix
+++ b/modules/mev-boost/args.nix
@@ -1,7 +1,7 @@
 lib:
 with lib; {
   network = mkOption {
-    type = types.nullOr (types.enum ["mainnet" "holesky" "sepolia" "zhejiang"]);
+    type = types.nullOr (types.enum ["mainnet" "holesky" "sepolia" "zhejiang" "hoodi"]);
     default = null;
     description = "The network to connect to. Mainnet (null) is the default ethereum network.";
   };

--- a/modules/nimbus-eth2/args.nix
+++ b/modules/nimbus-eth2/args.nix
@@ -10,6 +10,7 @@ with lib; {
         "holesky"
         "gnosis"
         "chiado"
+        "hoodi"
       ]
     );
     default = null;

--- a/pkgs/blutgang/default.nix
+++ b/pkgs/blutgang/default.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-EAmmCvESMneYuoTEa8Qm5eYqJkkRDY8CqlfsER1Pq8s=";
   };
 
-  cargoHash = "sha256-1G80j/lZrAlrgOLgpKyGYP9x6g/9kxXf3wmY2OcynFc=";
+  cargoHash = "sha256-JnUYPSsMQ4blE31L1c4R7QikUZ9k/XMqnuzeNNtjUVU=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -58,7 +58,7 @@
         # meta.platforms = [system];
         meta.platforms = ["x86_64-linux" "aarch64-linux"];
       });
-      geth = callPackage ./geth {};
+      geth = callPackageUnstable ./geth {};
       geth-sealer = callPackage ./geth-sealer {};
       heimdall = callPackage ./heimdall {};
       lighthouse = callPackageUnstable ./lighthouse {inherit foundry;};

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -21,7 +21,8 @@
     system,
     ...
   }: let
-    inherit (pkgs) callPackage;
+    inherit (pkgs) callPackage hostPlatform;
+    inherit (hostPlatform) isLinux;
     inherit (lib.extras.flakes) platformPkgs platformApps;
     callPackageUnstable = pkgsUnstable.callPackage;
     callPackage2311 = pkgs2311.callPackage;
@@ -33,71 +34,74 @@
       rustc = rustToolchain;
     };
   in {
-    packages = platformPkgs system rec {
-      besu = callPackageUnstable ./besu {};
-      bls = callPackage ./bls {};
-      blst = callPackage ./blst {};
-      blutgang = callPackage ./blutgang {inherit (pkgsUnstable) rustPlatform;};
-      charon = callPackage ./charon {inherit bls mcl;};
-      dirk = callPackage ./dirk {inherit bls mcl;};
-      dreamboat = callPackage ./dreamboat {inherit blst;};
-      eigenlayer = callPackage ./eigenlayer {};
-      erigon = callPackage ./erigon {};
-      erigon-blst-portable = erigon.overrideAttrs (_finalAttrs: _previousAttrs: {
-        CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
-      });
-      eth2-testnet-genesis = callPackage ./eth2-testnet-genesis {inherit bls;};
-      eth2-val-tools = callPackage ./eth2-val-tools {inherit bls mcl;};
-      eth-validator-watcher = callPackage2311 ./eth-validator-watcher {};
-      ethdo = callPackage ./ethdo {inherit bls mcl;};
-      ethereal = callPackage ./ethereal {inherit bls mcl;};
-      evmc = callPackage ./evmc {};
-      foundry = callPackageUnstable ./foundry {inherit rustPlatform;};
-      foundry-bin = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {
-        # TODO: Uncomment when https://github.com/shazow/foundry.nix/issues/23
-        # meta.platforms = [system];
-        meta.platforms = ["x86_64-linux" "aarch64-linux"];
-      });
-      geth = callPackageUnstable ./geth {};
-      geth-sealer = callPackage ./geth-sealer {};
-      heimdall = callPackage ./heimdall {};
-      lighthouse = callPackageUnstable ./lighthouse {inherit foundry;};
-      mcl = callPackage ./mcl {};
-      mev-boost = callPackageUnstable ./mev-boost {inherit blst;};
-      mev-boost-builder = callPackage ./mev-boost-builder {inherit blst;};
-      mev-boost-relay = callPackage ./mev-boost-relay {inherit blst;};
-      mev-rs = callPackage ./mev-rs {};
-      nethermind = callPackageUnstable ./nethermind {};
-      nimbus = callPackageUnstable ./nimbus {};
-      prysm = callPackage ./prysm {inherit bls blst;};
-      reth = callPackageUnstable ./reth {};
-      rocketpool = callPackage ./rocketpool {};
-      rocketpoold = callPackage ./rocketpoold {inherit bls blst;};
-      rotki-bin = callPackageUnstable ./rotki-bin {};
-      sedge = callPackage2311 ./sedge {
-        bls = callPackage2311 ./bls {};
-        mcl = callPackage2311 ./mcl {};
+    packages =
+      platformPkgs system rec {
+        besu = callPackageUnstable ./besu {};
+        bls = callPackage ./bls {};
+        blst = callPackage ./blst {};
+        blutgang = callPackage ./blutgang {inherit (pkgsUnstable) rustPlatform;};
+        charon = callPackage ./charon {inherit bls mcl;};
+        dirk = callPackage ./dirk {inherit bls mcl;};
+        dreamboat = callPackage ./dreamboat {inherit blst;};
+        eigenlayer = callPackage ./eigenlayer {};
+        erigon = callPackage ./erigon {};
+        erigon-blst-portable = erigon.overrideAttrs (_finalAttrs: _previousAttrs: {
+          CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
+        });
+        eth2-testnet-genesis = callPackage ./eth2-testnet-genesis {inherit bls;};
+        eth2-val-tools = callPackage ./eth2-val-tools {inherit bls mcl;};
+        eth-validator-watcher = callPackage2311 ./eth-validator-watcher {};
+        ethdo = callPackage ./ethdo {inherit bls mcl;};
+        ethereal = callPackage ./ethereal {inherit bls mcl;};
+        evmc = callPackage ./evmc {};
+        foundry = callPackageUnstable ./foundry {inherit rustPlatform;};
+        foundry-bin = inputs.foundry-nix.defaultPackage.${system}.overrideAttrs (_oldAttrs: {
+          # TODO: Uncomment when https://github.com/shazow/foundry.nix/issues/23
+          # meta.platforms = [system];
+          meta.platforms = ["x86_64-linux" "aarch64-linux"];
+        });
+        geth = callPackageUnstable ./geth {};
+        geth-sealer = callPackage ./geth-sealer {};
+        heimdall = callPackage ./heimdall {};
+        lighthouse = callPackageUnstable ./lighthouse {inherit foundry;};
+        mcl = callPackage ./mcl {};
+        mev-boost = callPackageUnstable ./mev-boost {inherit blst;};
+        mev-boost-builder = callPackage ./mev-boost-builder {inherit blst;};
+        mev-boost-relay = callPackage ./mev-boost-relay {inherit blst;};
+        mev-rs = callPackage ./mev-rs {};
+        nethermind = callPackageUnstable ./nethermind {};
+        prysm = callPackage ./prysm {inherit bls blst;};
+        reth = callPackageUnstable ./reth {};
+        rocketpool = callPackage ./rocketpool {};
+        rocketpoold = callPackage ./rocketpoold {inherit bls blst;};
+        rotki-bin = callPackageUnstable ./rotki-bin {};
+        sedge = callPackage2311 ./sedge {
+          bls = callPackage2311 ./bls {};
+          mcl = callPackage2311 ./mcl {};
+        };
+        slither = callPackage ./slither {};
+        snarkjs = callPackage ./snarkjs {};
+        ssv-dkg = callPackage2311 ./ssv-dkg {
+          bls = callPackage2311 ./bls {};
+          mcl = callPackage2311 ./mcl {};
+        };
+        ssvnode = callPackage ./ssvnode {
+          bls = callPackage2311 ./bls {};
+          mcl = callPackage2311 ./mcl {};
+        };
+        staking-deposit-cli = callPackage ./staking-deposit-cli {};
+        teku = callPackage ./teku {};
+        tx-fuzz = callPackage ./tx-fuzz {};
+        vouch = callPackage ./vouch {inherit bls mcl;};
+        vouch-unstable = callPackage ./vouch/unstable.nix {inherit bls mcl;};
+        vscode-plugin-ackee-blockchain-solidity-tools = callPackage ./ackee-blockchain.solidity-tools {};
+        vscode-plugin-consensys-vscode-solidity-visual-editor = callPackage ./consensys.vscode-solidity-auditor {};
+        web3signer = callPackage ./web3signer {};
+        zcli = callPackage ./zcli {};
+      }
+      // lib.optionalAttrs isLinux {
+        nimbus = inputs'.nimbus-eth2.packages.beacon_node;
       };
-      slither = callPackage ./slither {};
-      snarkjs = callPackage ./snarkjs {};
-      ssv-dkg = callPackage2311 ./ssv-dkg {
-        bls = callPackage2311 ./bls {};
-        mcl = callPackage2311 ./mcl {};
-      };
-      ssvnode = callPackage ./ssvnode {
-        bls = callPackage2311 ./bls {};
-        mcl = callPackage2311 ./mcl {};
-      };
-      staking-deposit-cli = callPackage ./staking-deposit-cli {};
-      teku = callPackage ./teku {};
-      tx-fuzz = callPackage ./tx-fuzz {};
-      vouch = callPackage ./vouch {inherit bls mcl;};
-      vouch-unstable = callPackage ./vouch/unstable.nix {inherit bls mcl;};
-      vscode-plugin-ackee-blockchain-solidity-tools = callPackage ./ackee-blockchain.solidity-tools {};
-      vscode-plugin-consensys-vscode-solidity-visual-editor = callPackage ./consensys.vscode-solidity-auditor {};
-      web3signer = callPackage ./web3signer {};
-      zcli = callPackage ./zcli {};
-    };
 
     apps = platformApps self'.packages {
       besu.bin = "besu";
@@ -138,10 +142,10 @@
         nethermind.bin = "nethermind-cli";
         nethermind-runner.bin = "nethermind";
       };
-      nimbus = {
-        nimbus-beacon-node.bin = "nimbus_beacon_node";
-        nimbus-validator-client.bin = "nimbus_validator_client";
-      };
+      # nimbus = {
+      #   nimbus-beacon-node.bin = "nimbus_beacon_node";
+      #   nimbus-validator-client.bin = "nimbus_validator_client";
+      # };
       prysm = {
         prysm-beacon-chain.bin = "beacon-chain";
         prysm-validator.bin = "validator";

--- a/pkgs/geth/default.nix
+++ b/pkgs/geth/default.nix
@@ -20,16 +20,16 @@
 in
   buildGoModule rec {
     pname = "geth";
-    version = "1.15.2";
+    version = "1.15.6";
     src = fetchFromGitHub {
       owner = "ethereum";
       repo = "go-ethereum";
       rev = "v${version}";
-      hash = "sha256-eaUkPl8vQzvotYfZcnuBwphSfO33RPjWOYhyNNvXli4=";
+      hash = "sha256-BdNv0rx+9/F0leNj2AAej8psy8X8HysDrIXheVOOkSo=";
     };
 
     proxyVendor = true;
-    vendorHash = "sha256-cfBTSroeDb/htGzIWG8c9Jty+Qo0TrQBrnyYy/Yo2C4=";
+    vendorHash = "sha256-1FuVdx84jvMBo8VO6q+WaFpK3hWn88J7p8vhIDsQHPM=";
 
     ldflags = ["-s" "-w"];
 

--- a/pkgs/mev-boost/default.nix
+++ b/pkgs/mev-boost/default.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule rec {
   pname = "mev-boost";
-  version = "1.9-rc2";
+  version = "1.9-rc3";
 
   src = fetchFromGitHub {
     owner = "flashbots";
     repo = "${pname}";
     rev = "v${version}";
-    hash = "sha256-TRcqtX3V7OagWlpiT8tK7P4Up27JE7EHtacFJbsHau4=";
+    hash = "sha256-wBIK0J1KJpJPHjjsR8NeKeJfBjWMjc6Dbw8CZ+sOlfc=";
   };
 
-  vendorHash = "sha256-YUm9Kz+pB8fPSh3eOdrfk2OMc7fNj1gXD7IeYiW2cuQ=";
+  vendorHash = "sha256-V1KEMgS3dlPZjHZKLUKdFvbRT7Iq5h38wqDsHMXP/rU=";
 
   buildInputs = [blst];
 

--- a/pkgs/nethermind/default.nix
+++ b/pkgs/nethermind/default.nix
@@ -12,14 +12,13 @@
 }: let
   self = buildDotnetModule rec {
     pname = "nethermind";
-    version = "1.31.1";
+    version = "1.31.6";
 
     src = fetchFromGitHub {
       owner = "NethermindEth";
       repo = pname;
       rev = version;
-      hash = "sha256-B86iVpDAztR9zZVBmMhN7M79PfpSXof4ny6iFb5GWpc=";
-      fetchSubmodules = true;
+      hash = "sha256-kBZUJaJ8eJT6flY7iPV6ypg1NbXU1u8w9/wmbwsOlDY=";
     };
 
     buildInputs = [

--- a/pkgs/nethermind/nuget-deps.nix
+++ b/pkgs/nethermind/nuget-deps.nix
@@ -266,8 +266,8 @@
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.App.Runtime.linux-x64";
-    version = "9.0.0";
-    hash = "sha256-4VhYI4XJ0XyKlRju6r/8wvf9xfJGtBcdadAv8Cr/OcY=";
+    version = "9.0.2";
+    hash = "sha256-aen2v5TY3eRh4FZcxZHQgwe3l20Z5egHEqDnoTut00M=";
   })
   (fetchNuGet {
     pname = "Microsoft.AspNetCore.Cryptography.Internal";
@@ -353,11 +353,6 @@
     pname = "Microsoft.CodeAnalysis.Analyzers";
     version = "3.3.3";
     hash = "sha256-pkZiggwLw8k+CVSXKTzsVGsT+K49LxXUS3VH5PNlpCY=";
-  })
-  (fetchNuGet {
-    pname = "Microsoft.CodeAnalysis.Analyzers";
-    version = "3.3.4";
-    hash = "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE=";
   })
   (fetchNuGet {
     pname = "Microsoft.CodeAnalysis.Common";
@@ -846,8 +841,8 @@
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.App.Runtime.linux-x64";
-    version = "9.0.0";
-    hash = "sha256-jfCFsvpF16NHB2zmwenOJgP7vx0gzx3KhszaxZE/KCk=";
+    version = "9.0.2";
+    hash = "sha256-u0/nrznoWiCkmN8U4JapclZOxdPTZz3AQxLaXQkHzr0=";
   })
   (fetchNuGet {
     pname = "Microsoft.NETCore.DotNetHost";
@@ -971,8 +966,8 @@
   })
   (fetchNuGet {
     pname = "Nethermind.Crypto.Bls";
-    version = "1.0.4";
-    hash = "sha256-gd8Z89j7FkemjxAgwH2SZC5rwBA8BJNsUBVBYf4KhUg=";
+    version = "1.0.5";
+    hash = "sha256-EI8JsiEKw+laRhA3n+PFivJtAcyfGZJ+dIuBlqpdiKw=";
   })
   (fetchNuGet {
     pname = "Nethermind.Crypto.Pairings";
@@ -1500,6 +1495,12 @@
     hash = "sha256-QNg0JJNx+zXMQ26MJRPzH7THdtqjrNtGLUgaR1SdvOk=";
   })
   (fetchNuGet {
+    pname = "System.CommandLine";
+    version = "2.0.0-beta4.24528.1";
+    hash = "sha256-C1CMTF8ejnnk9h6Yih8ajWeNiQK6czWZTgBSEhGZNGQ=";
+    url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/system.commandline/2.0.0-beta4.24528.1/system.commandline.2.0.0-beta4.24528.1.nupkg";
+  })
+  (fetchNuGet {
     pname = "System.ComponentModel";
     version = "4.0.1";
     hash = "sha256-X5T36S49q1odsn6wAET6EGNlsxOyd66naMr5T3G9mGw=";
@@ -1783,12 +1784,6 @@
     pname = "System.IO.MemoryMappedFiles";
     version = "4.0.0";
     hash = "sha256-1VQa8FoMUNAsja31OvOn7ungif+IPusAe9YcR+kRF6o=";
-  })
-  (fetchNuGet {
-    pname = "System.CommandLine";
-    version = "2.0.0-beta4.24528.1";
-    hash = "sha256-C1CMTF8ejnnk9h6Yih8ajWeNiQK6czWZTgBSEhGZNGQ=";
-    url = "https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/516521bf-6417-457e-9a9c-0a4bdfde03e7/nuget/v3/flat2/system.commandline/2.0.0-beta4.24528.1/system.commandline.2.0.0-beta4.24528.1.nupkg";
   })
   (fetchNuGet {
     pname = "System.IO.Pipelines";

--- a/pkgs/nimbus/default.nix
+++ b/pkgs/nimbus/default.nix
@@ -4,12 +4,12 @@
   targets ? ["nimbus_beacon_node" "nimbus_validator_client" "gnosis-build" "gnosis-vc-build"],
   stableSystems ? ["x86_64-linux" "aarch64-linux"],
 }: let
-  version = "25.2.0";
+  version = "25.3.1";
   src = fetchFromGitHub {
     owner = "status-im";
     repo = "nimbus-eth2";
     rev = "v${version}";
-    hash = "sha256-INALxgkuZ4kT/DrpzMBqgNeM8Ar78BRccmGWtqoGhB0=";
+    hash = "sha256-3/FXHzq6YrJUNa9/nHaV8xXn3IOqCT5ymf6VU6wlXIk=";
     fetchSubmodules = true;
   };
 in

--- a/pkgs/web3signer/default.nix
+++ b/pkgs/web3signer/default.nix
@@ -7,11 +7,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "web3signer";
-  version = "25.2.0";
+  version = "25.3.0";
 
   src = fetchzip {
-    url = "https://artifacts.consensys.net/public/${pname}/raw/names/${pname}.tar.gz/versions/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-8OWAywZkMXP4IDW9CSrjKCIHZmVipxzUti2Psp+maAU=";
+    url = "https://github.com/Consensys/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-T2J288f4fzcY3ZQXKQEdY4FwvmqtNeIH7qt0qxEAjOA=";
   };
 
   nativeBuildInputs = [makeWrapper];


### PR DESCRIPTION
- **nethermind: 1.31.3 > 1.31.6**
- **nimbus: 25.2.0 > 25.3.1**
- **mev-boost: 1.9-rc2 > 1.9.rc3**
- **geth: 1.15.2 > 1.15.6**
- **web3signer: 25.2.0 > 25.3.0**
- **config(modules): Add hoodi network to mev-boost, nimbus, and geth**
- **config(pkgs): Get nimbus package from status-im repo**
- **chore(flake): Update nixpkgs-unstable input**
- **update(blutgang): Update cargo hash**
- **config(mdformat): Use older package**